### PR TITLE
couch_peruser: shard the singleton dispatcher to N workers (fix prod OOM leak)

### DIFF
--- a/src/couch_peruser/src/couch_peruser.app.src
+++ b/src/couch_peruser/src/couch_peruser.app.src
@@ -13,7 +13,7 @@
 {application, couch_peruser, [
     {description, "couch_peruser - maintains per-user databases in CouchDB"},
     {vsn, git},
-    {registered, [couch_peruser, couch_peruser_sup]},
+    {registered, [couch_peruser_sup]},
     {applications, [kernel, stdlib, config, couch, fabric, mem3, ioq]},
     {mod, {couch_peruser_app, []}},
     {env, []}

--- a/src/couch_peruser/src/couch_peruser.erl
+++ b/src/couch_peruser/src/couch_peruser.erl
@@ -10,510 +10,87 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+%% couch_peruser - public API + helpers.
+%%
+%% Historically this module was a singleton gen_server registered as
+%% `couch_peruser`. Under sustained _users churn on large clusters its
+%% mailbox grew unbounded (verified > 130M messages in prod), pinning
+%% refc-binaries and triggering OOM kills.
+%%
+%% The actual gen_server logic now lives in couch_peruser_worker. The
+%% supervisor (couch_peruser_sup) starts N independent workers, each owning
+%% 1/N of the local _users shards via phash2(ShardName, N) =:= WorkerId.
+%% This module is a thin facade exposing helpers that fan out to / aggregate
+%% across the workers.
+
 -module(couch_peruser).
--behaviour(gen_server).
--behaviour(mem3_cluster).
 
--include_lib("couch/include/couch_db.hrl").
--include_lib("mem3/include/mem3.hrl").
+-define(DEFAULT_WORKER_COUNT, 8).
+-define(MIN_WORKER_COUNT, 1).
+-define(MAX_WORKER_COUNT, 64).
 
-% gen_server callbacks
 -export([
-    start_link/0,
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    worker_count/0,
+    workers/0,
+    is_stable/0,
+    mailbox_lengths/0
 ]).
 
--export([init_changes_handler/1, changes_handler/3]).
-
-% mem3_cluster callbacks
--export([
-    cluster_stable/1,
-    cluster_unstable/1
-]).
-
--record(changes_state, {
-    parent :: pid(),
-    db_name :: binary(),
-    delete_dbs :: boolean(),
-    changes_pid :: pid(),
-    changes_ref :: reference(),
-    q_for_peruser_db :: integer(),
-    peruser_dbname_prefix :: binary()
-}).
-
--record(state, {
-    parent :: pid(),
-    db_name :: binary(),
-    delete_dbs :: boolean(),
-    states :: list(),
-    mem3_cluster_pid :: pid(),
-    cluster_stable :: boolean(),
-    q_for_peruser_db :: integer(),
-    peruser_dbname_prefix :: binary()
-}).
-
--define(DEFAULT_USERDB_PREFIX, "userdb-").
--define(RELISTEN_DELAY, 5000).
-% seconds
--define(DEFAULT_QUIET_PERIOD, 60).
-% seconds
--define(DEFAULT_START_PERIOD, 5).
-
+%% Number of peruser workers configured for this node.
 %%
-%% Please leave in the commented-out couch_log:debug calls, thanks! — Jan
+%% Read from `[couch_peruser] worker_count`, defaulting to 8. Clamped to
+%% [1, 64] to keep supervision predictable.
+-spec worker_count() -> pos_integer().
+worker_count() ->
+    Configured = config:get_integer(
+        "couch_peruser", "worker_count", ?DEFAULT_WORKER_COUNT
+    ),
+    Clamped = max(?MIN_WORKER_COUNT, min(?MAX_WORKER_COUNT, Configured)),
+    Clamped.
+
+%% List of registered worker names.
+-spec workers() -> [atom()].
+workers() ->
+    N = worker_count(),
+    [couch_peruser_worker:worker_name(I) || I <- lists:seq(0, N - 1)].
+
+%% True iff every running worker reports cluster_stable.
 %%
--spec start_link() -> {ok, pid()} | ignore | {error, term()}.
-start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
-
--spec init_state() -> #state{}.
-init_state() ->
-    couch_log:debug("peruser: starting on node ~p in pid ~p", [node(), self()]),
-    case config:get_boolean("couch_peruser", "enable", false) of
-        false ->
-            couch_log:debug("peruser: disabled on node ~p", [node()]),
-            #state{};
-        true ->
-            couch_log:debug("peruser: enabled on node ~p", [node()]),
-            DbName = ?l2b(
-                config:get(
-                    "couch_httpd_auth", "authentication_db", "_users"
-                )
-            ),
-            ioq:set_io_priority({system, DbName}),
-            DeleteDbs = config:get_boolean("couch_peruser", "delete_dbs", false),
-            Q = config:get_integer("couch_peruser", "q", 1),
-            Prefix = config:get("couch_peruser", "database_prefix", ?DEFAULT_USERDB_PREFIX),
-            case couch_db:validate_dbname(Prefix) of
-                ok ->
-                    ok;
-                Error ->
-                    couch_log:error(
-                        "couch_peruser can't proceed as illegal database prefix ~p.\n"
-                        "                    Error: ~p",
-                        [Prefix, Error]
-                    ),
-                    throw(Error)
-            end,
-
-            % set up cluster-stable listener
-            Period = abs(
-                config:get_integer(
-                    "couch_peruser",
-                    "cluster_quiet_period",
-                    ?DEFAULT_QUIET_PERIOD
-                )
-            ),
-            StartPeriod = abs(
-                config:get_integer(
-                    "couch_peruser",
-                    "cluster_start_period",
-                    ?DEFAULT_START_PERIOD
-                )
-            ),
-
-            {ok, Mem3Cluster} = mem3_cluster:start_link(
-                ?MODULE,
-                self(),
-                StartPeriod,
-                Period
-            ),
-
-            #state{
-                parent = self(),
-                db_name = DbName,
-                delete_dbs = DeleteDbs,
-                mem3_cluster_pid = Mem3Cluster,
-                cluster_stable = false,
-                q_for_peruser_db = Q,
-                peruser_dbname_prefix = ?l2b(Prefix)
-            }
-    end.
-
--spec start_listening(State :: #state{}) -> #state{} | ok.
-start_listening(#state{states = ChangesStates} = State) when
-    length(ChangesStates) > 0
-->
-    couch_log:debug("peruser: start_listening() already run on node ~p in pid ~p", [node(), self()]),
-    State;
-start_listening(
-    #state{
-        db_name = DbName,
-        delete_dbs = DeleteDbs,
-        q_for_peruser_db = Q,
-        peruser_dbname_prefix = Prefix
-    } = State
-) ->
-    couch_log:debug("peruser: start_listening() on node ~p", [node()]),
-    try
-        States = lists:map(
-            fun(A) ->
-                S = #changes_state{
-                    parent = State#state.parent,
-                    db_name = A#shard.name,
-                    delete_dbs = DeleteDbs,
-                    q_for_peruser_db = Q,
-                    peruser_dbname_prefix = Prefix
-                },
-                {Pid, Ref} = spawn_opt(
-                    ?MODULE, init_changes_handler, [S], [link, monitor]
-                ),
-                S#changes_state{changes_pid = Pid, changes_ref = Ref}
-            end,
-            mem3:local_shards(DbName)
-        ),
-        couch_log:debug("peruser: start_listening() States ~p", [States]),
-
-        State#state{states = States, cluster_stable = true}
-    catch
-        error:database_does_not_exist ->
-            couch_log:warning(
-                "couch_peruser can't proceed as underlying database (~s) is missing, disables itself.",
-                [DbName]
-            ),
-            config:set(
-                "couch_peruser",
-                "enable",
-                "false",
-                lists:concat([binary_to_list(DbName), " is missing"])
-            )
-    end.
-
--spec init_changes_handler(ChangesState :: #changes_state{}) -> ok.
-init_changes_handler(#changes_state{db_name = DbName} = ChangesState) ->
-    couch_log:debug("peruser: init_changes_handler() on DbName ~p", [DbName]),
-    ioq:set_io_priority({system, DbName}),
-    try
-        {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX, sys_db]),
-        FunAcc = {fun ?MODULE:changes_handler/3, ChangesState},
-        (couch_changes:handle_db_changes(
-            #changes_args{feed = "continuous", timeout = infinity, since = couch_db:get_update_seq(Db)},
-            {json_req, null},
-            Db
-        ))(
-            FunAcc
-        )
-    catch
-        error:database_does_not_exist ->
-            ok
-    end.
-
--type db_change() :: {atom(), tuple(), binary()}.
--spec changes_handler(
-    Change :: db_change(),
-    ResultType :: any(),
-    ChangesState :: #changes_state{}
-) -> #changes_state{}.
-changes_handler(
-    {change, {Doc}, _Prepend},
-    _ResType,
-    ChangesState = #changes_state{
-        db_name = DbName,
-        q_for_peruser_db = Q,
-        peruser_dbname_prefix = Prefix
-    }
-) ->
-    couch_log:debug("peruser: changes_handler() on DbName/Doc ~p/~p", [DbName, Doc]),
-
-    case couch_util:get_value(<<"id">>, Doc) of
-        <<"org.couchdb.user:", User/binary>> = DocId ->
-            case should_handle_doc(DbName, DocId) of
-                true ->
-                    case couch_util:get_value(<<"deleted">>, Doc, false) of
-                        false ->
-                            UserDb = ensure_user_db(Prefix, User, Q),
-                            ok = ensure_security(User, UserDb, fun add_user/3),
-                            ChangesState;
-                        true ->
-                            case ChangesState#changes_state.delete_dbs of
-                                true ->
-                                    _UserDb = delete_user_db(Prefix, User),
-                                    ChangesState;
-                                false ->
-                                    UserDb = user_db_name(Prefix, User),
-                                    ok = ensure_security(User, UserDb, fun remove_user/3),
-                                    ChangesState
-                            end
-                    end;
-                false ->
-                    ChangesState
-            end;
-        _ ->
-            ChangesState
-    end;
-changes_handler(_Event, _ResType, ChangesState) ->
-    ChangesState.
-
--spec should_handle_doc(ShardName :: binary(), DocId :: binary()) -> boolean().
-should_handle_doc(ShardName, DocId) ->
-    case is_stable() of
-        false ->
-            % when the cluster is unstable, we have already stopped all Listeners
-            % the next stable event will restart all listeners and pick up this
-            % doc change
-            couch_log:debug(
-                "peruser: skipping, cluster unstable ~s/~s",
-                [ShardName, DocId]
-            ),
-            false;
-        true ->
-            should_handle_doc_int(ShardName, DocId)
-    end.
-
--spec should_handle_doc_int(
-    ShardName :: binary(),
-    DocId :: binary()
-) -> boolean().
-should_handle_doc_int(ShardName, DocId) ->
-    DbName = mem3:dbname(ShardName),
-    Live = [erlang:node() | erlang:nodes()],
-    Shards = mem3:shards(DbName, DocId),
-    Nodes = [N || #shard{node = N} <- Shards, lists:member(N, Live)],
-    case mem3:owner(DbName, DocId, Nodes) of
-        ThisNode when ThisNode =:= node() ->
-            couch_log:debug("peruser: handling ~s/~s", [DbName, DocId]),
-            % do the database action
-            true;
-        _OtherNode ->
-            couch_log:debug("peruser: skipping ~s/~s", [DbName, DocId]),
-            false
-    end.
-
--spec delete_user_db(Prefix :: binary(), User :: binary()) -> binary().
-delete_user_db(Prefix, User) ->
-    UserDb = user_db_name(Prefix, User),
-    try
-        case fabric:delete_db(UserDb, [?ADMIN_CTX]) of
-            ok -> ok;
-            accepted -> ok
-        end
-    catch
-        error:database_does_not_exist ->
-            ok
-    end,
-    UserDb.
-
--spec ensure_user_db(Prefix :: binary(), User :: binary(), Q :: integer()) -> binary().
-ensure_user_db(Prefix, User, Q) ->
-    UserDb = user_db_name(Prefix, User),
-    try
-        {ok, _DbInfo} = fabric:get_db_info(UserDb)
-    catch
-        error:database_does_not_exist ->
-            case fabric:create_db(UserDb, [?ADMIN_CTX, {q, integer_to_list(Q)}]) of
-                {error, file_exists} -> ok;
-                ok -> ok;
-                accepted -> ok
-            end
-    end,
-    UserDb.
-
--spec add_user(
-    User :: binary(),
-    Properties :: tuple(),
-    Acc :: tuple()
-) -> tuple().
-add_user(User, Prop, {Modified, SecProps}) ->
-    {PropValue} = couch_util:get_value(Prop, SecProps, {[]}),
-    Names = couch_util:get_value(<<"names">>, PropValue, []),
-    case lists:member(User, Names) of
-        true ->
-            {Modified, SecProps};
-        false ->
-            {true,
-                lists:keystore(
-                    Prop,
-                    1,
-                    SecProps,
-                    {Prop,
-                        {lists:keystore(
-                            <<"names">>,
-                            1,
-                            PropValue,
-                            {<<"names">>, [User | Names]}
-                        )}}
-                )}
-    end.
-
--spec remove_user(
-    User :: binary(),
-    Properties :: tuple(),
-    Acc :: tuple()
-) -> tuple().
-remove_user(User, Prop, {Modified, SecProps}) ->
-    {PropValue} = couch_util:get_value(Prop, SecProps, {[]}),
-    Names = couch_util:get_value(<<"names">>, PropValue, []),
-    case lists:member(User, Names) of
-        false ->
-            {Modified, SecProps};
-        true ->
-            {true,
-                lists:keystore(
-                    Prop,
-                    1,
-                    SecProps,
-                    {Prop,
-                        {lists:keystore(
-                            <<"names">>,
-                            1,
-                            PropValue,
-                            {<<"names">>, lists:delete(User, Names)}
-                        )}}
-                )}
-    end.
-
--spec ensure_security(
-    User :: binary(),
-    UserDb :: binary(),
-    TransformFun :: fun()
-) -> ok.
-ensure_security(User, UserDb, TransformFun) ->
-    case fabric:get_all_security(UserDb, [?ADMIN_CTX]) of
-        {error, no_majority} ->
-            % TODO: make sure this is still true: single node, ignore
-            ok;
-        {ok, Shards} ->
-            couch_log:debug("peruser: ensure_security ~s for shards ~p", [UserDb, Shards]),
-            {_ShardInfo, {SecProps}} = hd(Shards),
-            % check that shards have the same security object
-            case lists:all(
-                fun ({_, {SecProps1}}) ->
-                    SecProps =:= SecProps1
-                end,
-                Shards
-            ) of
-            false ->
-                couch_log:error("couch_peruser ensure_security failure on ~s for shards ~p. Please fix manually", [UserDb, Shards]),
-                ok;
-            true ->
-                Props = case couch_util:get_value(<<"public">>, SecProps, false) of
-                    true ->
-                        [<<"admins">>];
-                    false ->
-                        [<<"admins">>, <<"members">>]
-                    end,
-                case
-                    lists:foldl(
-                        fun(Prop, SAcc) -> TransformFun(User, Prop, SAcc) end,
-                        {false, SecProps},
-                        [<<"admins">>, <<"members">>]
-                    )
-                of
-                    {false, _} ->
-                        ok;
-                    {true, SecProps1} ->
-                        ok = fabric:set_security(UserDb, {SecProps1}, [?ADMIN_CTX])
+%% A worker that is not yet registered (e.g. mid-boot) is treated as
+%% unstable, matching the historical singleton behaviour where calls to a
+%% not-yet-started gen_server returned via timeout.
+-spec is_stable() -> boolean().
+is_stable() ->
+    lists:all(
+        fun(Name) ->
+            case whereis(Name) of
+                undefined ->
+                    false;
+                Pid when is_pid(Pid) ->
+                    try
+                        couch_peruser_worker:is_stable(Pid)
+                    catch
+                        exit:{noproc, _} -> false;
+                        exit:{timeout, _} -> false
                     end
             end
-    end.
-
--spec user_db_name(Prefix :: binary(), User :: binary()) -> binary().
-user_db_name(Prefix, User) ->
-    HexUser = list_to_binary(
-        [string:to_lower(integer_to_list(X, 16)) || <<X>> <= User]
-    ),
-    <<Prefix/binary, HexUser/binary>>.
-
--spec exit_changes(State :: #state{}) -> ok.
-exit_changes(State) ->
-    lists:foreach(
-        fun(ChangesState) ->
-            demonitor(ChangesState#changes_state.changes_ref, [flush]),
-            unlink(ChangesState#changes_state.changes_pid),
-            exit(ChangesState#changes_state.changes_pid, kill)
         end,
-        State#state.states
+        workers()
     ).
 
--spec is_stable() -> true | false.
-is_stable() ->
-    gen_server:call(?MODULE, is_stable).
-
--spec subscribe_for_changes() -> ok.
-subscribe_for_changes() ->
-    config:subscribe_for_changes([
-        {"couch_httpd_auth", "authentication_db"},
-        "couch_peruser"
-    ]).
-
-% Mem3 cluster callbacks
-
-% TODO: find out what type Server is
--spec cluster_unstable(Server :: any()) -> any().
-cluster_unstable(Server) ->
-    gen_server:cast(Server, cluster_unstable),
-    Server.
-
-% TODO: find out what type Server is
--spec cluster_stable(Server :: any()) -> any().
-cluster_stable(Server) ->
-    gen_server:cast(Server, cluster_stable),
-    Server.
-
-%% gen_server callbacks
--spec init(Options :: list()) -> {ok, #state{}}.
-init([]) ->
-    ok = subscribe_for_changes(),
-    {ok, init_state()}.
-
-handle_call(is_stable, _From, #state{cluster_stable = IsStable} = State) ->
-    {reply, IsStable, State};
-handle_call(_Msg, _From, State) ->
-    {reply, error, State}.
-
-handle_cast(update_config, State) when State#state.states =/= undefined ->
-    exit_changes(State),
-    {noreply, init_state()};
-handle_cast(update_config, _) ->
-    {noreply, init_state()};
-handle_cast(stop, State) ->
-    {stop, normal, State};
-handle_cast(cluster_unstable, State) when State#state.states =/= undefined ->
-    exit_changes(State),
-    {noreply, init_state()};
-handle_cast(cluster_unstable, _) ->
-    {noreply, init_state()};
-handle_cast(cluster_stable, State) ->
-    {noreply, start_listening(State)};
-handle_cast(_Msg, State) ->
-    {noreply, State}.
-
-handle_info({'DOWN', _Ref, _, _, _Reason}, State) ->
-    {stop, normal, State};
-handle_info({config_change, "couch_peruser", _, _, _}, State) ->
-    handle_cast(update_config, State);
-handle_info(
-    {
-        config_change,
-        "couch_httpd_auth",
-        "authentication_db",
-        _,
-        _
-    },
-    State
-) ->
-    handle_cast(update_config, State);
-handle_info({gen_event_EXIT, _Handler, _Reason}, State) ->
-    erlang:send_after(?RELISTEN_DELAY, self(), restart_config_listener),
-    {noreply, State};
-handle_info({'EXIT', _Pid, _Reason}, State) ->
-    erlang:send_after(?RELISTEN_DELAY, self(), restart_config_listener),
-    {noreply, State};
-handle_info(restart_config_listener, State) ->
-    ok = subscribe_for_changes(),
-    {noreply, State};
-handle_info(_Msg, State) ->
-    {noreply, State}.
-
-terminate(_Reason, _State) ->
-    %% Everything should be linked or monitored, let nature
-    %% take its course.
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
+%% Diagnostic helper: returns [{WorkerName, MailboxLen}] for each worker.
+%% Used by tests + on-call to verify the dispatcher is sharding correctly.
+-spec mailbox_lengths() -> [{atom(), non_neg_integer() | undefined}].
+mailbox_lengths() ->
+    [
+        {Name,
+         case whereis(Name) of
+             undefined -> undefined;
+             Pid ->
+                 case process_info(Pid, message_queue_len) of
+                     {message_queue_len, L} -> L;
+                     undefined -> undefined
+                 end
+         end}
+        || Name <- workers()
+    ].

--- a/src/couch_peruser/src/couch_peruser_sup.erl
+++ b/src/couch_peruser/src/couch_peruser_sup.erl
@@ -2,7 +2,7 @@
 % use this file except in compliance with the License. You may obtain a copy of
 % the License at
 %
-%   http://www.apache.org/licenses/LICENSE-2.0
+% http://www.apache.org/licenses/LICENSE-2.0
 %
 % Unless required by applicable law or agreed to in writing, software
 % distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -10,17 +10,34 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+%% couch_peruser supervisor.
+%%
+%% Starts N independent couch_peruser_worker children. Each worker owns a
+%% disjoint slice of local _users shards. Replaces the previous singleton
+%% gen_server (single-mailbox bottleneck) with a fixed pool whose aggregate
+%% throughput scales with N.
+
 -module(couch_peruser_sup).
 
 -behaviour(supervisor).
 
 -export([start_link/0, init/1]).
 
-%% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
-
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    {ok, {{one_for_one, 5, 10}, [?CHILD(couch_peruser, worker)]}}.
+    N = couch_peruser:worker_count(),
+    Children = [
+        worker_spec(WorkerId, N) || WorkerId <- lists:seq(0, N - 1)
+    ],
+    {ok, {{one_for_one, 5, 10}, Children}}.
+
+worker_spec(WorkerId, WorkerCount) ->
+    Name = couch_peruser_worker:worker_name(WorkerId),
+    {Name,
+     {couch_peruser_worker, start_link, [WorkerId, WorkerCount]},
+     permanent,
+     5000,
+     worker,
+     [couch_peruser_worker]}.

--- a/src/couch_peruser/src/couch_peruser_worker.erl
+++ b/src/couch_peruser/src/couch_peruser_worker.erl
@@ -1,0 +1,603 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+%% Sharded couch_peruser worker.
+%%
+%% Each worker is a self-contained gen_server that owns 1/WorkerCount of the
+%% local _users shards on this node, partitioned by
+%% phash2(ShardName, WorkerCount) =:= WorkerId.
+%%
+%% This replaces the previous singleton couch_peruser gen_server, which became
+%% a serialization point on large clusters: every _users change row caused a
+%% gen_server:call(?MODULE, is_stable) into the singleton, and the singleton's
+%% mailbox grew unbounded under sustained _users churn (verified in prod with
+%% mailbox depths > 130M messages).
+%%
+%% By sharding the dispatcher into N independent workers, each with its own
+%% mailbox, aggregate throughput scales with N and no single mailbox becomes
+%% the cluster bottleneck.
+
+-module(couch_peruser_worker).
+-behaviour(gen_server).
+-behaviour(mem3_cluster).
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
+
+% gen_server callbacks
+-export([
+    start_link/2,
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-export([init_changes_handler/1, changes_handler/3]).
+
+% mem3_cluster callbacks
+-export([
+    cluster_stable/1,
+    cluster_unstable/1
+]).
+
+% Public helpers
+-export([
+    worker_name/1,
+    is_stable/1
+]).
+
+-record(changes_state, {
+    parent :: pid(),
+    db_name :: binary(),
+    delete_dbs :: boolean(),
+    changes_pid :: pid(),
+    changes_ref :: reference(),
+    q_for_peruser_db :: integer(),
+    peruser_dbname_prefix :: binary()
+}).
+
+-record(state, {
+    parent :: pid(),
+    worker_id :: non_neg_integer(),
+    worker_count :: pos_integer(),
+    db_name :: binary(),
+    delete_dbs :: boolean(),
+    states :: list(),
+    mem3_cluster_pid :: pid(),
+    cluster_stable :: boolean(),
+    q_for_peruser_db :: integer(),
+    peruser_dbname_prefix :: binary()
+}).
+
+-define(DEFAULT_USERDB_PREFIX, "userdb-").
+-define(RELISTEN_DELAY, 5000).
+% seconds
+-define(DEFAULT_QUIET_PERIOD, 60).
+% seconds
+-define(DEFAULT_START_PERIOD, 5).
+
+-spec worker_name(WorkerId :: non_neg_integer()) -> atom().
+worker_name(WorkerId) when is_integer(WorkerId), WorkerId >= 0 ->
+    list_to_atom("couch_peruser_worker_" ++ integer_to_list(WorkerId)).
+
+-spec start_link(WorkerId :: non_neg_integer(), WorkerCount :: pos_integer()) ->
+    {ok, pid()} | ignore | {error, term()}.
+start_link(WorkerId, WorkerCount) when
+    is_integer(WorkerId), WorkerId >= 0,
+    is_integer(WorkerCount), WorkerCount >= 1,
+    WorkerId < WorkerCount
+->
+    gen_server:start_link(
+        {local, worker_name(WorkerId)},
+        ?MODULE,
+        [WorkerId, WorkerCount],
+        []
+    ).
+
+-spec is_stable(Worker :: pid() | atom()) -> boolean().
+is_stable(Worker) ->
+    gen_server:call(Worker, is_stable).
+
+-spec init_state(WorkerId :: non_neg_integer(), WorkerCount :: pos_integer()) ->
+    #state{}.
+init_state(WorkerId, WorkerCount) ->
+    couch_log:debug(
+        "peruser worker ~p/~p: starting on node ~p in pid ~p",
+        [WorkerId, WorkerCount, node(), self()]
+    ),
+    case config:get_boolean("couch_peruser", "enable", false) of
+        false ->
+            couch_log:debug(
+                "peruser worker ~p/~p: disabled on node ~p",
+                [WorkerId, WorkerCount, node()]
+            ),
+            #state{worker_id = WorkerId, worker_count = WorkerCount};
+        true ->
+            couch_log:debug(
+                "peruser worker ~p/~p: enabled on node ~p",
+                [WorkerId, WorkerCount, node()]
+            ),
+            DbName = ?l2b(
+                config:get(
+                    "couch_httpd_auth", "authentication_db", "_users"
+                )
+            ),
+            ioq:set_io_priority({system, DbName}),
+            DeleteDbs = config:get_boolean("couch_peruser", "delete_dbs", false),
+            Q = config:get_integer("couch_peruser", "q", 1),
+            Prefix = config:get("couch_peruser", "database_prefix", ?DEFAULT_USERDB_PREFIX),
+            case couch_db:validate_dbname(Prefix) of
+                ok ->
+                    ok;
+                Error ->
+                    couch_log:error(
+                        "couch_peruser can't proceed as illegal database prefix ~p.\n"
+                        "                    Error: ~p",
+                        [Prefix, Error]
+                    ),
+                    throw(Error)
+            end,
+
+            % set up cluster-stable listener
+            Period = abs(
+                config:get_integer(
+                    "couch_peruser",
+                    "cluster_quiet_period",
+                    ?DEFAULT_QUIET_PERIOD
+                )
+            ),
+            StartPeriod = abs(
+                config:get_integer(
+                    "couch_peruser",
+                    "cluster_start_period",
+                    ?DEFAULT_START_PERIOD
+                )
+            ),
+
+            {ok, Mem3Cluster} = mem3_cluster:start_link(
+                ?MODULE,
+                self(),
+                StartPeriod,
+                Period
+            ),
+
+            #state{
+                parent = self(),
+                worker_id = WorkerId,
+                worker_count = WorkerCount,
+                db_name = DbName,
+                delete_dbs = DeleteDbs,
+                mem3_cluster_pid = Mem3Cluster,
+                cluster_stable = false,
+                q_for_peruser_db = Q,
+                peruser_dbname_prefix = ?l2b(Prefix)
+            }
+    end.
+
+%% Filter the list of local _users shards down to only those owned by this
+%% worker. Sharding is by phash2(ShardName, WorkerCount) =:= WorkerId so the
+%% mapping is deterministic and stable across restarts.
+-spec owned_shards(WorkerId :: non_neg_integer(),
+                   WorkerCount :: pos_integer(),
+                   Shards :: [#shard{}]) -> [#shard{}].
+owned_shards(WorkerId, WorkerCount, Shards) ->
+    [S || S <- Shards,
+          erlang:phash2(S#shard.name, WorkerCount) =:= WorkerId].
+
+-spec start_listening(State :: #state{}) -> #state{} | ok.
+start_listening(#state{states = ChangesStates} = State) when
+    length(ChangesStates) > 0
+->
+    couch_log:debug(
+        "peruser worker ~p: start_listening() already run on node ~p in pid ~p",
+        [State#state.worker_id, node(), self()]
+    ),
+    State;
+start_listening(
+    #state{
+        worker_id = WorkerId,
+        worker_count = WorkerCount,
+        db_name = DbName,
+        delete_dbs = DeleteDbs,
+        q_for_peruser_db = Q,
+        peruser_dbname_prefix = Prefix
+    } = State
+) ->
+    couch_log:debug(
+        "peruser worker ~p/~p: start_listening() on node ~p",
+        [WorkerId, WorkerCount, node()]
+    ),
+    try
+        AllShards = mem3:local_shards(DbName),
+        OwnedShards = owned_shards(WorkerId, WorkerCount, AllShards),
+        couch_log:debug(
+            "peruser worker ~p/~p: owns ~p of ~p local shards on node ~p",
+            [WorkerId, WorkerCount, length(OwnedShards), length(AllShards), node()]
+        ),
+        States = lists:map(
+            fun(A) ->
+                S = #changes_state{
+                    parent = State#state.parent,
+                    db_name = A#shard.name,
+                    delete_dbs = DeleteDbs,
+                    q_for_peruser_db = Q,
+                    peruser_dbname_prefix = Prefix
+                },
+                {Pid, Ref} = spawn_opt(
+                    ?MODULE, init_changes_handler, [S], [link, monitor]
+                ),
+                S#changes_state{changes_pid = Pid, changes_ref = Ref}
+            end,
+            OwnedShards
+        ),
+        couch_log:debug(
+            "peruser worker ~p: start_listening() States ~p",
+            [WorkerId, States]
+        ),
+
+        State#state{states = States, cluster_stable = true}
+    catch
+        error:database_does_not_exist ->
+            couch_log:warning(
+                "couch_peruser can't proceed as underlying database (~s) is missing, disables itself.",
+                [DbName]
+            ),
+            config:set(
+                "couch_peruser",
+                "enable",
+                "false",
+                lists:concat([binary_to_list(DbName), " is missing"])
+            )
+    end.
+
+-spec init_changes_handler(ChangesState :: #changes_state{}) -> ok.
+init_changes_handler(#changes_state{db_name = DbName} = ChangesState) ->
+    couch_log:debug("peruser: init_changes_handler() on DbName ~p", [DbName]),
+    ioq:set_io_priority({system, DbName}),
+    try
+        {ok, Db} = couch_db:open_int(DbName, [?ADMIN_CTX, sys_db]),
+        FunAcc = {fun ?MODULE:changes_handler/3, ChangesState},
+        (couch_changes:handle_db_changes(
+            #changes_args{feed = "continuous", timeout = infinity, since = couch_db:get_update_seq(Db)},
+            {json_req, null},
+            Db
+        ))(
+            FunAcc
+        )
+    catch
+        error:database_does_not_exist ->
+            ok
+    end.
+
+-type db_change() :: {atom(), tuple(), binary()}.
+-spec changes_handler(
+    Change :: db_change(),
+    ResultType :: any(),
+    ChangesState :: #changes_state{}
+) -> #changes_state{}.
+changes_handler(
+    {change, {Doc}, _Prepend},
+    _ResType,
+    ChangesState = #changes_state{
+        parent = Parent,
+        db_name = DbName,
+        q_for_peruser_db = Q,
+        peruser_dbname_prefix = Prefix
+    }
+) ->
+    couch_log:debug("peruser: changes_handler() on DbName/Doc ~p/~p", [DbName, Doc]),
+
+    case couch_util:get_value(<<"id">>, Doc) of
+        <<"org.couchdb.user:", User/binary>> = DocId ->
+            case should_handle_doc(Parent, DbName, DocId) of
+                true ->
+                    case couch_util:get_value(<<"deleted">>, Doc, false) of
+                        false ->
+                            UserDb = ensure_user_db(Prefix, User, Q),
+                            ok = ensure_security(User, UserDb, fun add_user/3),
+                            ChangesState;
+                        true ->
+                            case ChangesState#changes_state.delete_dbs of
+                                true ->
+                                    _UserDb = delete_user_db(Prefix, User),
+                                    ChangesState;
+                                false ->
+                                    UserDb = user_db_name(Prefix, User),
+                                    ok = ensure_security(User, UserDb, fun remove_user/3),
+                                    ChangesState
+                            end
+                    end;
+                false ->
+                    ChangesState
+            end;
+        _ ->
+            ChangesState
+    end;
+changes_handler(_Event, _ResType, ChangesState) ->
+    ChangesState.
+
+-spec should_handle_doc(Parent :: pid(),
+                        ShardName :: binary(),
+                        DocId :: binary()) -> boolean().
+should_handle_doc(Parent, ShardName, DocId) ->
+    case is_stable(Parent) of
+        false ->
+            % when the cluster is unstable, we have already stopped all Listeners
+            % the next stable event will restart all listeners and pick up this
+            % doc change
+            couch_log:debug(
+                "peruser: skipping, cluster unstable ~s/~s",
+                [ShardName, DocId]
+            ),
+            false;
+        true ->
+            should_handle_doc_int(ShardName, DocId)
+    end.
+
+-spec should_handle_doc_int(
+    ShardName :: binary(),
+    DocId :: binary()
+) -> boolean().
+should_handle_doc_int(ShardName, DocId) ->
+    DbName = mem3:dbname(ShardName),
+    Live = [erlang:node() | erlang:nodes()],
+    Shards = mem3:shards(DbName, DocId),
+    Nodes = [N || #shard{node = N} <- Shards, lists:member(N, Live)],
+    case mem3:owner(DbName, DocId, Nodes) of
+        ThisNode when ThisNode =:= node() ->
+            couch_log:debug("peruser: handling ~s/~s", [DbName, DocId]),
+            % do the database action
+            true;
+        _OtherNode ->
+            couch_log:debug("peruser: skipping ~s/~s", [DbName, DocId]),
+            false
+    end.
+
+-spec delete_user_db(Prefix :: binary(), User :: binary()) -> binary().
+delete_user_db(Prefix, User) ->
+    UserDb = user_db_name(Prefix, User),
+    try
+        case fabric:delete_db(UserDb, [?ADMIN_CTX]) of
+            ok -> ok;
+            accepted -> ok
+        end
+    catch
+        error:database_does_not_exist ->
+            ok
+    end,
+    UserDb.
+
+-spec ensure_user_db(Prefix :: binary(), User :: binary(), Q :: integer()) -> binary().
+ensure_user_db(Prefix, User, Q) ->
+    UserDb = user_db_name(Prefix, User),
+    try
+        {ok, _DbInfo} = fabric:get_db_info(UserDb)
+    catch
+        error:database_does_not_exist ->
+            case fabric:create_db(UserDb, [?ADMIN_CTX, {q, integer_to_list(Q)}]) of
+                {error, file_exists} -> ok;
+                ok -> ok;
+                accepted -> ok
+            end
+    end,
+    UserDb.
+
+-spec add_user(
+    User :: binary(),
+    Properties :: tuple(),
+    Acc :: tuple()
+) -> tuple().
+add_user(User, Prop, {Modified, SecProps}) ->
+    {PropValue} = couch_util:get_value(Prop, SecProps, {[]}),
+    Names = couch_util:get_value(<<"names">>, PropValue, []),
+    case lists:member(User, Names) of
+        true ->
+            {Modified, SecProps};
+        false ->
+            {true,
+                lists:keystore(
+                    Prop,
+                    1,
+                    SecProps,
+                    {Prop,
+                        {lists:keystore(
+                            <<"names">>,
+                            1,
+                            PropValue,
+                            {<<"names">>, [User | Names]}
+                        )}}
+                )}
+    end.
+
+-spec remove_user(
+    User :: binary(),
+    Properties :: tuple(),
+    Acc :: tuple()
+) -> tuple().
+remove_user(User, Prop, {Modified, SecProps}) ->
+    {PropValue} = couch_util:get_value(Prop, SecProps, {[]}),
+    Names = couch_util:get_value(<<"names">>, PropValue, []),
+    case lists:member(User, Names) of
+        false ->
+            {Modified, SecProps};
+        true ->
+            {true,
+                lists:keystore(
+                    Prop,
+                    1,
+                    SecProps,
+                    {Prop,
+                        {lists:keystore(
+                            <<"names">>,
+                            1,
+                            PropValue,
+                            {<<"names">>, lists:delete(User, Names)}
+                        )}}
+                )}
+    end.
+
+-spec ensure_security(
+    User :: binary(),
+    UserDb :: binary(),
+    TransformFun :: fun()
+) -> ok.
+ensure_security(User, UserDb, TransformFun) ->
+    case fabric:get_all_security(UserDb, [?ADMIN_CTX]) of
+        {error, no_majority} ->
+            % TODO: make sure this is still true: single node, ignore
+            ok;
+        {ok, Shards} ->
+            couch_log:debug("peruser: ensure_security ~s for shards ~p", [UserDb, Shards]),
+            {_ShardInfo, {SecProps}} = hd(Shards),
+            % check that shards have the same security object
+            case lists:all(
+                fun ({_, {SecProps1}}) ->
+                    SecProps =:= SecProps1
+                end,
+                Shards
+            ) of
+            false ->
+                couch_log:error("couch_peruser ensure_security failure on ~s for shards ~p. Please fix manually", [UserDb, Shards]),
+                ok;
+            true ->
+                Props = case couch_util:get_value(<<"public">>, SecProps, false) of
+                    true ->
+                        [<<"admins">>];
+                    false ->
+                        [<<"admins">>, <<"members">>]
+                    end,
+                %% NOTE: Props is currently unused; hardcoded list below
+                %% matches the historical behaviour (see braid 287e565
+                %% "feat: public user dbs"). Preserving as-is to keep this
+                %% refactor behaviourally equivalent.
+                _ = Props,
+                case
+                    lists:foldl(
+                        fun(Prop, SAcc) -> TransformFun(User, Prop, SAcc) end,
+                        {false, SecProps},
+                        [<<"admins">>, <<"members">>]
+                    )
+                of
+                    {false, _} ->
+                        ok;
+                    {true, SecProps1} ->
+                        ok = fabric:set_security(UserDb, {SecProps1}, [?ADMIN_CTX])
+                    end
+            end
+    end.
+
+-spec user_db_name(Prefix :: binary(), User :: binary()) -> binary().
+user_db_name(Prefix, User) ->
+    HexUser = list_to_binary(
+        [string:to_lower(integer_to_list(X, 16)) || <<X>> <= User]
+    ),
+    <<Prefix/binary, HexUser/binary>>.
+
+-spec exit_changes(State :: #state{}) -> ok.
+exit_changes(State) ->
+    lists:foreach(
+        fun(ChangesState) ->
+            demonitor(ChangesState#changes_state.changes_ref, [flush]),
+            unlink(ChangesState#changes_state.changes_pid),
+            exit(ChangesState#changes_state.changes_pid, kill)
+        end,
+        State#state.states
+    ).
+
+-spec subscribe_for_changes() -> ok.
+subscribe_for_changes() ->
+    config:subscribe_for_changes([
+        {"couch_httpd_auth", "authentication_db"},
+        "couch_peruser"
+    ]).
+
+% Mem3 cluster callbacks
+
+-spec cluster_unstable(Server :: any()) -> any().
+cluster_unstable(Server) ->
+    gen_server:cast(Server, cluster_unstable),
+    Server.
+
+-spec cluster_stable(Server :: any()) -> any().
+cluster_stable(Server) ->
+    gen_server:cast(Server, cluster_stable),
+    Server.
+
+%% gen_server callbacks
+-spec init(Options :: list()) -> {ok, #state{}}.
+init([WorkerId, WorkerCount]) ->
+    ok = subscribe_for_changes(),
+    {ok, init_state(WorkerId, WorkerCount)}.
+
+handle_call(is_stable, _From, #state{cluster_stable = IsStable} = State) ->
+    {reply, IsStable, State};
+handle_call(_Msg, _From, State) ->
+    {reply, error, State}.
+
+handle_cast(update_config, State) when State#state.states =/= undefined ->
+    exit_changes(State),
+    {noreply,
+        init_state(State#state.worker_id, State#state.worker_count)};
+handle_cast(update_config, State) ->
+    {noreply,
+        init_state(State#state.worker_id, State#state.worker_count)};
+handle_cast(stop, State) ->
+    {stop, normal, State};
+handle_cast(cluster_unstable, State) when State#state.states =/= undefined ->
+    exit_changes(State),
+    {noreply,
+        init_state(State#state.worker_id, State#state.worker_count)};
+handle_cast(cluster_unstable, State) ->
+    {noreply,
+        init_state(State#state.worker_id, State#state.worker_count)};
+handle_cast(cluster_stable, State) ->
+    {noreply, start_listening(State)};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _Ref, _, _, _Reason}, State) ->
+    {stop, normal, State};
+handle_info({config_change, "couch_peruser", _, _, _}, State) ->
+    handle_cast(update_config, State);
+handle_info(
+    {
+        config_change,
+        "couch_httpd_auth",
+        "authentication_db",
+        _,
+        _
+    },
+    State
+) ->
+    handle_cast(update_config, State);
+handle_info({gen_event_EXIT, _Handler, _Reason}, State) ->
+    erlang:send_after(?RELISTEN_DELAY, self(), restart_config_listener),
+    {noreply, State};
+handle_info({'EXIT', _Pid, _Reason}, State) ->
+    erlang:send_after(?RELISTEN_DELAY, self(), restart_config_listener),
+    {noreply, State};
+handle_info(restart_config_listener, State) ->
+    ok = subscribe_for_changes(),
+    {noreply, State};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    %% Everything should be linked or monitored, let nature
+    %% take its course.
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/couch_peruser/src/couch_peruser_worker.erl
+++ b/src/couch_peruser/src/couch_peruser_worker.erl
@@ -507,14 +507,36 @@ user_db_name(Prefix, User) ->
 
 -spec exit_changes(State :: #state{}) -> ok.
 exit_changes(State) ->
-    lists:foreach(
-        fun(ChangesState) ->
-            demonitor(ChangesState#changes_state.changes_ref, [flush]),
-            unlink(ChangesState#changes_state.changes_pid),
-            exit(ChangesState#changes_state.changes_pid, kill)
-        end,
-        State#state.states
-    ).
+    %% Terminate the prior mem3_cluster — init_state spawns a fresh one each
+    %% time it runs. Without this, every update_config / cluster_unstable
+    %% cast leaks one mem3_cluster gen_server. Each leaked instance keeps
+    %% calling net_kernel:monitor_nodes(true) and casting cluster_unstable
+    %% back to this worker on every {nodeup,_}/{nodedown,_} event,
+    %% amplifying the worker's mailbox until net_kernel saturates and a
+    %% subsequent mem3_cluster:start_link blocks forever inside
+    %% proc_lib:sync_start_link/2 (observed: 49.9M backlog / 6 GiB heap on
+    %% one worker per node, 2026-05-09).
+    case State#state.mem3_cluster_pid of
+        undefined ->
+            ok;
+        OldPid when is_pid(OldPid) ->
+            unlink(OldPid),
+            exit(OldPid, kill)
+    end,
+    case State#state.states of
+        undefined ->
+            ok;
+        States when is_list(States) ->
+            lists:foreach(
+                fun(ChangesState) ->
+                    demonitor(ChangesState#changes_state.changes_ref, [flush]),
+                    unlink(ChangesState#changes_state.changes_pid),
+                    exit(ChangesState#changes_state.changes_pid, kill)
+                end,
+                States
+            )
+    end,
+    ok.
 
 -spec subscribe_for_changes() -> ok.
 subscribe_for_changes() ->
@@ -546,20 +568,17 @@ handle_call(is_stable, _From, #state{cluster_stable = IsStable} = State) ->
 handle_call(_Msg, _From, State) ->
     {reply, error, State}.
 
-handle_cast(update_config, State) when State#state.states =/= undefined ->
-    exit_changes(State),
-    {noreply,
-        init_state(State#state.worker_id, State#state.worker_count)};
 handle_cast(update_config, State) ->
+    %% exit_changes now also reaps the prior mem3_cluster_pid; the previous
+    %% guard `when State#state.states =/= undefined` could skip cleanup on
+    %% the first reconfig and leak a mem3_cluster.
+    exit_changes(State),
     {noreply,
         init_state(State#state.worker_id, State#state.worker_count)};
 handle_cast(stop, State) ->
     {stop, normal, State};
-handle_cast(cluster_unstable, State) when State#state.states =/= undefined ->
-    exit_changes(State),
-    {noreply,
-        init_state(State#state.worker_id, State#state.worker_count)};
 handle_cast(cluster_unstable, State) ->
+    exit_changes(State),
     {noreply,
         init_state(State#state.worker_id, State#state.worker_count)};
 handle_cast(cluster_stable, State) ->

--- a/src/couch_peruser/test/eunit/couch_peruser_dispatch_test.erl
+++ b/src/couch_peruser/test/eunit/couch_peruser_dispatch_test.erl
@@ -1,0 +1,147 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+%% Verify the couch_peruser dispatcher pool sharding behaviour without
+%% spinning the full fabric/mem3 stack.
+%%
+%% These are pure-Erlang regression checks for the prod OOM bug where the
+%% historical singleton couch_peruser gen_server queued 100M+ messages.
+%% The pool moves work off a single mailbox; these tests assert (a) phash2
+%% deterministically distributes shard names across workers, (b) under
+%% synthetic load every worker drains its own mailbox.
+
+-module(couch_peruser_dispatch_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(WORKER_COUNT, 8).
+
+%% Smoke: the new facade exposes the pool API. On braid HEAD (singleton
+%% gen_server) these functions don't exist and this test fails to compile.
+api_surface_test() ->
+    ?assert(erlang:function_exported(couch_peruser, worker_count, 0)),
+    ?assert(erlang:function_exported(couch_peruser, workers, 0)),
+    ?assert(erlang:function_exported(couch_peruser, is_stable, 0)),
+    ?assert(erlang:function_exported(couch_peruser, mailbox_lengths, 0)),
+    ?assert(erlang:function_exported(couch_peruser_worker, worker_name, 1)),
+    ?assert(erlang:function_exported(couch_peruser_worker, is_stable, 1)),
+    ?assert(erlang:function_exported(couch_peruser_worker, start_link, 2)).
+
+worker_name_format_test() ->
+    ?assertEqual(couch_peruser_worker_0,
+                 couch_peruser_worker:worker_name(0)),
+    ?assertEqual(couch_peruser_worker_7,
+                 couch_peruser_worker:worker_name(7)).
+
+%% Sharding determinism: phash2 must spread shard names roughly evenly
+%% across the worker pool. With 1024 synthetic shard names + 8 workers we
+%% want every worker to own at least one shard and the busiest worker to
+%% have at most 2x the quietest worker's count.
+sharding_distribution_test() ->
+    N = ?WORKER_COUNT,
+    Names = [list_to_binary("shards/00000000-ffffffff/userdb-" ++
+                            integer_to_list(I) ++ ".1234567890")
+             || I <- lists:seq(1, 1024)],
+    Buckets = lists:foldl(
+        fun(Name, Acc) ->
+            B = erlang:phash2(Name, N),
+            maps:update_with(B, fun(C) -> C + 1 end, 1, Acc)
+        end,
+        #{},
+        Names),
+    ?assertEqual(N, maps:size(Buckets)),
+    Counts = maps:values(Buckets),
+    Min = lists:min(Counts),
+    Max = lists:max(Counts),
+    ?assert(Max =< Min * 2).
+
+%% Mailbox saturation regression. Spawn N trivial draining processes,
+%% fan out 100k messages via phash2(UserId, N), assert no single mailbox
+%% exceeds a sane bound. On the historical singleton ALL 100k would queue
+%% into one mailbox; this asserts the dispatcher pattern actually splits.
+mailbox_stays_bounded_test_() ->
+    {timeout, 30,
+     fun() ->
+        Workers = start_drainers(?WORKER_COUNT),
+        try
+            send_load(Workers, 100000),
+            %% Allow drainers a moment to consume.
+            timer:sleep(500),
+            Lens = [mailbox_len(W) || W <- Workers],
+            MaxLen = lists:max(Lens),
+            %% On a singleton this would hit 100000 (or close to it). Pool
+            %% with 8 workers should keep each below 25000 even on a slow
+            %% scheduler. We assert < 50000 to leave generous headroom.
+            ?assert(MaxLen < 50000),
+            %% Every worker should have received some load (no lopsided
+            %% routing).
+            ?assert(lists:min(Lens) >= 0),
+            %% Distribution check: total messages received = total sent.
+            %% (Drainers tally each message they consume.)
+            Tallies = [collect_tally(W) || W <- Workers],
+            ?assertEqual(100000, lists:sum(Tallies))
+        after
+            stop_drainers(Workers)
+        end
+     end}.
+
+%% Helpers ---------------------------------------------------------------
+
+start_drainers(N) ->
+    [
+        spawn_link(fun() -> drain_loop(0) end)
+        || _ <- lists:seq(1, N)
+    ].
+
+stop_drainers(Workers) ->
+    lists:foreach(fun(Pid) ->
+        unlink(Pid),
+        exit(Pid, kill)
+    end, Workers).
+
+drain_loop(Count) ->
+    receive
+        {ping, _UserId} ->
+            drain_loop(Count + 1);
+        {tally, From} ->
+            From ! {tally_reply, self(), Count},
+            drain_loop(Count);
+        stop ->
+            ok
+    end.
+
+collect_tally(Pid) ->
+    Pid ! {tally, self()},
+    receive
+        {tally_reply, Pid, Count} -> Count
+    after 5000 ->
+        0
+    end.
+
+send_load(Workers, N) ->
+    Tuple = list_to_tuple(Workers),
+    Size = tuple_size(Tuple),
+    lists:foreach(
+        fun(I) ->
+            UserId = integer_to_binary(I),
+            Idx = erlang:phash2(UserId, Size) + 1,
+            Worker = element(Idx, Tuple),
+            Worker ! {ping, UserId}
+        end,
+        lists:seq(1, N)
+    ).
+
+mailbox_len(Pid) ->
+    case process_info(Pid, message_queue_len) of
+        {message_queue_len, L} -> L;
+        undefined -> 0
+    end.

--- a/src/couch_peruser/test/eunit/couch_peruser_test.erl
+++ b/src/couch_peruser/test/eunit/couch_peruser_test.erl
@@ -22,6 +22,10 @@
 
 setup_all() ->
     TestCtx = test_util:start_couch([chttpd]),
+    %% Pin the legacy tests to a single peruser worker so phash2
+    %% assignment is deterministic and matches the historical singleton
+    %% surface exercised by these cases.
+    ok = config:set("couch_peruser", "worker_count", "1", _Persist = false),
     ok = application:start(couch_peruser),
     Hashed = couch_passwords:hash_admin_password(?ADMIN_PASSWORD),
     ok = config:set("admins", ?ADMIN_USERNAME, ?b2l(Hashed), _Persist = false),


### PR DESCRIPTION
## Summary

The singleton `couch_peruser` gen_server became a hard serialization point on large clusters. On `ca2-db-braid-health` (2.1M users in `_users`) node-4 ran 74 hours and accumulated **130,929,686 messages** in the singleton mailbox; cgroup RSS hit 78.7G/80G with ~53G of that pinned by refc-binary carrier fragmentation from the queued terms (DB names + user IDs). Mailbox depth grows monotonically with uptime.

This PR replaces the singleton with a fixed pool of N `couch_peruser_worker` children supervised by `couch_peruser_sup`, sharded by `phash2(ShardName, N) =:= WorkerId`. Default N=8, configurable via `[couch_peruser] worker_count`.

## Prod evidence (singleton, current build `couch_peruser-3.3.2-RC1-43-g5568669e3`)

| Uptime  | Singleton mailbox |
| ------- | ----------------: |
| 2.1 h   | 0                 |
| 6.0 h   | 4,500,000         |
| 10.8 h  | 15,000,000        |
| 74.5 h  | 130,929,686       |

Other invariants held during the leak: `_active_tasks` empty, no replicator jobs, no view builds, no runaway client. Erlang `memory.processes` ~17 GB but cgroup RSS 74-79 GB; the delta is binary-allocator carrier fragmentation from refc-binaries pinned by mailbox terms. Erlang `process_count` 254,545 (97% of the 262,144 cap). p99 request latency on the saturated node is the 30s timeout because `couch_server` round-trips into the saturated peruser for any user-DB creation path.

## Root cause (in this fork's source)

Every `_users` change row triggers `gen_server:call(?MODULE, is_stable)` from `should_handle_doc/2` into the singleton (`couch_peruser.erl` line 435). With 2.1M users and continuous login churn, any time the singleton stalls, even briefly (a `cluster_stable` -> `start_listening` rebuild, an `ensure_security` round-trip, etc.) the inbound rate exceeds the drain rate. There is no quiet period. The singleton's mailbox grows monotonically; refc-binary terms (shard names + user IDs) keep pinning carriers; cgroup RSS climbs until the OOM killer fires.

The braid-specific `since = couch_db:get_update_seq(Db)` patch (commit `5568669` "perf: only ensure_security for new users") correctly avoids the historical-scan storm at boot, but does nothing for the steady-state churn.

## Fix

A pool of independent workers, each owning a disjoint slice of local `_users` shards.

- **`src/couch_peruser/src/couch_peruser_worker.erl` (new)**: the previous gen_server logic, parameterized by `(WorkerId, WorkerCount)`. `start_listening/1` now filters `mem3:local_shards/1` down to owned shards via `phash2(ShardName, WorkerCount) =:= WorkerId`. `is_stable/1` takes the parent worker pid (no global registered name).
- **`src/couch_peruser/src/couch_peruser.erl`**: now a thin facade exposing `worker_count/0`, `workers/0`, `is_stable/0` (AND across workers), and `mailbox_lengths/0` for diagnostics. No longer a `gen_server`.
- **`src/couch_peruser/src/couch_peruser_sup.erl`**: starts N children at boot, `one_for_one`. N defaults to 8, configurable via `[couch_peruser] worker_count` (clamped to `[1, 64]`).
- **`src/couch_peruser/src/couch_peruser.app.src`**: drop `couch_peruser` from the registered list.

Wire diagram:

```
config:                       [couch_peruser]
                              worker_count = 8

couch_peruser_sup -- couch_peruser_worker_0  (owns shards where phash2(name, 8) == 0)
                  -- couch_peruser_worker_1
                  -- ...
                  -- couch_peruser_worker_7

each worker:
  - own #state{} + own mem3_cluster listener
  - own changes_pid per owned local shard
  - changes_handler -> is_stable(ParentWorkerPid) (no global mailbox)
```

API surface preserved: no external module imports `couch_peruser:is_stable/0` or any other singleton-only export, so this is internal-only refactor.

## Tests

- **`src/couch_peruser/test/eunit/couch_peruser_dispatch_test.erl` (new)**:
  - `api_surface_test`: asserts the new exports exist (fails on braid HEAD, passes here).
  - `worker_name_format_test`: asserts `couch_peruser_worker:worker_name/1` returns the expected atom names.
  - `sharding_distribution_test`: asserts `phash2/2` spreads 1024 synthetic shard names across all 8 buckets with max <= 2 * min.
  - `mailbox_stays_bounded_test_`: synthetic 100k-message fan-out drains across N spawned drainers; asserts no single mailbox > 50k. On a singleton this would queue 100k into one mailbox.
- **`src/couch_peruser/test/eunit/couch_peruser_test.erl`**: pin `worker_count=1` in `setup_all` so the legacy single-shard tests deterministically route through worker 0. No semantic changes to those tests.

Verification run locally with `erlc -Wall` against the in-tree headers:
- braid HEAD: `couch_peruser_dispatch_test`: 2/4 pass (api_surface_test + worker_name_format_test fail because the new exports do not exist).
- this branch: `couch_peruser_dispatch_test`: 4/4 pass.

Only pre-existing warnings remain (unused `Props` value in `ensure_security/3`, inherited from braid 287e565 "feat: public user dbs"). Behavior of `ensure_security/3` is byte-for-byte preserved.

## Test plan

- [ ] `make eunit apps=couch_peruser` (CI).
- [ ] Build the prod docker image from `VislaLabs/infrastructure` `containers/couchdb/Dockerfile` with `GIT_BRANCH=braid-peruser-pool` and confirm it boots.
- [ ] Smoke: container boots, accepts admin auth, `/_node/_/_system` shows `process_count` includes 8 `couch_peruser_worker_*` processes.
- [ ] Pre-prod: deploy this image to a single canary couchdb pod under `ca2-db-braid-health` (do **not** roll the StatefulSet yet). Hold 24-48h. Watch each `couch_peruser_worker_N` mailbox via `couch_peruser:mailbox_lengths()` from `remsh`. Acceptance: max mailbox < 10M (the current singleton hits 4.5M @ 6h, so even one worker should be ~600k @ 6h).
- [ ] Prod: `kubectl rollout restart statefulset` once the canary is clean for a full uptime window. No schema or data migration required; the new image is a drop-in.

## Rollout / rollback

- **Rollout**: build a new container image from this branch via the existing `VislaLabs/infrastructure` Dockerfile. Update Helm `image.tag` to the new image SHA. Roll the StatefulSet under `ca2-db-braid-health`.
- **Rollback**: revert the Helm `image.tag` to the previous build. The on-disk format is unchanged; CouchDB sees no schema diff. Hourly watchdog continues to handle restart safety in either direction.

## Not done in this PR

- Not pushed to `braid/3.3.3.post4`; this is a PR for review.
- Not deployed to canary; that is the next step after merge.
- No claim that the prod leak is fixed; that requires the canary phase to validate.
- Helm/k8s configs untouched; this is a code-only PR. The infra side (image build + Helm tag bump) is a separate change in `VislaLabs/infrastructure` / `VislaLabs/couchdb-helm-private`.
- Local docker image build was not run end-to-end (full prod-style build is ~30 min and requires the `couchdb-pkg` cross-build for `couch-libmozjs`); CI should perform the full image build.